### PR TITLE
Curator file io

### DIFF
--- a/lib/artists.csv
+++ b/lib/artists.csv
@@ -1,0 +1,7 @@
+id,name,born,died,country
+1,Henri Cartier-Bresson,1908,2004,France
+2,Ansel Adams,1902,1984,United States
+3,Diane Arbus,1923,1971,United States
+4,Walker Evans,1903,1975,United States
+5,Manuel Alvarez Bravo,1902,2002,Mexico
+6,Bill Cunningham,1929,2016,United States

--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -59,4 +59,18 @@ class Curator
       photographs << Photograph.new(info)
     end
   end
+
+  def load_artists(file_path)
+    table = CSV.table(file_path)
+    table.each do |line|
+      info = {
+        id: line[:id],
+        name: line[:name],
+        born: line[:born],
+        died: line[:died],
+        country: line[:country]
+      }
+      artists << Artist.new(info)
+    end
+  end
 end

--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -45,4 +45,16 @@ class Curator
       end
     end.compact
   end
+
+  def load_photographs(file_path)
+    File.foreach(file_path) do |line|
+      info = {
+        id: line[0],
+        name: line[1],
+        artist_id: line[2],
+        year: line[3]
+      }
+      photographs << Photograph.new(info)
+    end
+  end
 end

--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -56,5 +56,6 @@ class Curator
       }
       photographs << Photograph.new(info)
     end
+    photographs.delete_at(0)
   end
 end

--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -1,3 +1,4 @@
+require 'csv'
 class Curator
   attr_reader :photographs, :artists
 
@@ -47,15 +48,15 @@ class Curator
   end
 
   def load_photographs(file_path)
-    File.foreach(file_path) do |line|
+    table = CSV.table(file_path)
+    table.each do |line|
       info = {
-        id: line[0],
-        name: line[1],
-        artist_id: line[2],
-        year: line[3]
+        id: line[:id],
+        name: line[:name],
+        artist_id: line[:artist_id],
+        year: line[:year]
       }
       photographs << Photograph.new(info)
     end
-    photographs.delete_at(0)
   end
 end

--- a/lib/photographs.csv
+++ b/lib/photographs.csv
@@ -1,0 +1,5 @@
+id,name,artist_id,year
+1,"Rue Mouffetard, Paris (Boy with Bottles)",1,1954
+2,"Moonrise, Hernandez",2,1941
+3,"Identical Twins, Roselle, New Jersey",3,1967
+4,Child with Toy Hand Grenade in Central Park,3,1962

--- a/test/curator_test.rb
+++ b/test/curator_test.rb
@@ -98,13 +98,14 @@ class CuratorTest < Minitest::Test
 
     assert_equal 4, @curator.photographs.length
     assert_instance_of Photograph, @curator.photographs.first
+    assert_equal "Rue Mouffetard, Paris (Boy with Bottles)", @curator.photographs.first.name
   end
 
-  def test_it_can_load_artists_from_a_file
-    file = "./lib/artists.csv"
-    @curator.load_artists(file)
-
-    assert_equal 6, @curator.artists.length
-    assert_instance_of Artist, @curator.artists.first
-  end
+  # def test_it_can_load_artists_from_a_file
+  #   file = "./lib/artists.csv"
+  #   @curator.load_artists(file)
+  #
+  #   assert_equal 6, @curator.artists.length
+  #   assert_instance_of Artist, @curator.artists.first
+  # end
 end

--- a/test/curator_test.rb
+++ b/test/curator_test.rb
@@ -96,6 +96,7 @@ class CuratorTest < Minitest::Test
     file = "./lib/photo_file.csv"
     @curator.load_photographs(file)
 
-    assert_equal [@rue, @moonrise], @curator.photographs
+    assert_equal 2, @curator.photographs.length
+    assert_instance_of Photograph, @curator.photographs.first
   end
 end

--- a/test/curator_test.rb
+++ b/test/curator_test.rb
@@ -91,4 +91,11 @@ class CuratorTest < Minitest::Test
 
     assert_empty @curator.photographs_taken_by_artists_from("Argentina")
   end
+
+  def test_it_can_load_photographs_from_a_file
+    file = "./lib/photo_file.csv"
+    @curator.load_photographs(file)
+
+    assert_equal [@rue, @moonrise], @curator.photographs
+  end
 end

--- a/test/curator_test.rb
+++ b/test/curator_test.rb
@@ -96,7 +96,15 @@ class CuratorTest < Minitest::Test
     file = "./lib/photographs.csv"
     @curator.load_photographs(file)
 
-    assert_equal 5, @curator.photographs.length
+    assert_equal 4, @curator.photographs.length
     assert_instance_of Photograph, @curator.photographs.first
+  end
+
+  def test_it_can_load_artists_from_a_file
+    file = "./lib/artists.csv"
+    @curator.load_artists(file)
+
+    assert_equal 6, @curator.artists.length
+    assert_instance_of Artist, @curator.artists.first
   end
 end

--- a/test/curator_test.rb
+++ b/test/curator_test.rb
@@ -93,10 +93,10 @@ class CuratorTest < Minitest::Test
   end
 
   def test_it_can_load_photographs_from_a_file
-    file = "./lib/photo_file.csv"
+    file = "./lib/photographs.csv"
     @curator.load_photographs(file)
 
-    assert_equal 2, @curator.photographs.length
+    assert_equal 5, @curator.photographs.length
     assert_instance_of Photograph, @curator.photographs.first
   end
 end

--- a/test/curator_test.rb
+++ b/test/curator_test.rb
@@ -101,11 +101,12 @@ class CuratorTest < Minitest::Test
     assert_equal "Rue Mouffetard, Paris (Boy with Bottles)", @curator.photographs.first.name
   end
 
-  # def test_it_can_load_artists_from_a_file
-  #   file = "./lib/artists.csv"
-  #   @curator.load_artists(file)
-  #
-  #   assert_equal 6, @curator.artists.length
-  #   assert_instance_of Artist, @curator.artists.first
-  # end
+  def test_it_can_load_artists_from_a_file
+    file = "./lib/artists.csv"
+    @curator.load_artists(file)
+
+    assert_equal 6, @curator.artists.length
+    assert_instance_of Artist, @curator.artists.first
+    assert_equal "Henri Cartier-Bresson", @curator.artists.first.name
+  end
 end


### PR DESCRIPTION
This PR implements a new feature to the Curator class, allowing them to load Artist and Photo information through a CSV file. This allows for a quicker process to get information into a Curator, rather than loading each Artist or Photograph individually.
This takes a CSV file, turns it into a table, and then pulls each line of that table. Each line is then turned into a Information hash, which is then fed into our Curator Artist/Photograph arrays.
Our tests cover specific information to ensure that the files were loaded correctly.