### PR TITLE
Photos between range

### DIFF
--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -73,4 +73,12 @@ class Curator
       artists << Artist.new(info)
     end
   end
+
+  def photographs_taken_between(range)
+    photographs.find_all do |photo|
+      range.any? do |year|
+        photo.year == year
+      end
+    end
+  end
 end

--- a/test/curator_test.rb
+++ b/test/curator_test.rb
@@ -109,4 +109,12 @@ class CuratorTest < Minitest::Test
     assert_instance_of Artist, @curator.artists.first
     assert_equal "Henri Cartier-Bresson", @curator.artists.first.name
   end
+
+  def test_it_can_find_photographs_within_a_range
+    file = "./lib/photographs.csv"
+    @curator.load_photographs(file)
+
+    assert_equal 2, @curator.photographs_taken_between(1950..1965).length
+    assert_equal "Rue Mouffetard, Paris (Boy with Bottles)", @curator.photographs_taken_between(1950..1965).first.name
+  end
 end


### PR DESCRIPTION
This PR implements the Curator method #photos_within_range, allowing us to search for only the photos that fall within a range of years.
A relatively simple method, it takes a range as an argument, and then iterates through all of the loaded Photos. If the Photos year matched any number within the range, it will put it into our return array.